### PR TITLE
Fix clear eventHandler when removeClient

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = {
     if(clientIdx > -1)
       this.clients.splice(clientIdx, 1);
 
-    if(this.clients.length > 0) {
+    if(this.clients.length === 0) {
       this.eventHandler.remove();
       this.eventHandler = null;
     }


### PR DESCRIPTION
### Context

My app has a use case to clear all MQTT client on logout and re-create the client when login again.

But when removeClient the check `if(this.clients.length > 0)` always return false, therefore it won't remove the `eventHandler` resulting when I create new client it could not set up MQTT events again.